### PR TITLE
HDWallet.from_index missing return statement

### DIFF
--- a/hdwallet/hdwallet.py
+++ b/hdwallet/hdwallet.py
@@ -455,7 +455,7 @@ class HDWallet:
                 self._path += str("/" + index)
         return self
 
-    def from_index(self, index: int, hardened: bool = False) -> "HDWallet":
+    def from_index(self, index: int, hardened: bool = False) -> Optional["HDWallet"]:
         """
         Derivation from Index.
 
@@ -464,7 +464,7 @@ class HDWallet:
         :param hardened: Hardened address, default to ``False``.
         :type hardened: bool
 
-        :returns: HDWallet -- Hierarchical Deterministic Wallet instance.
+        :returns: Optional[HDWallet] -- Hierarchical Deterministic Wallet instance.
 
         >>> from hdwallet import HDWallet
         >>> from hdwallet.symbols import BTC
@@ -483,7 +483,7 @@ class HDWallet:
 
         if hardened:
             self._path += ("/%d'" % index)
-            self._derive_key_by_index(index + BIP32KEY_HARDEN)
+            return self._derive_key_by_index(index + BIP32KEY_HARDEN)
         else:
             self._path += ("/%d" % index)
             return self._derive_key_by_index(index)


### PR DESCRIPTION
The Issue:

Deriving from index returns None if hardened is set to True in **all cases**
```
>>> from hdwallet import HDWallet
>>> from hdwallet.symbols import BTC
>>> hdwallet = HDWallet(symbol=BTC)
>>> hdwallet.from_xprivate_key(xprivate_key="xprv9s21ZrQH143K3xPGUzpogJeKtRdjHkK6muBJo8v7rEVRzT83xJgNcLpMoJXUf9wJFKfuHR4SGvfgdShh4t9VmjjrE9usBunK3LfNna31LGF")
>>> child_node = hdwallet.from_index(index=44, hardened=True)
>>> child_node is None
True
```

Expected Behavior:
```
>>> child_node = hdwallet.from_index(index=44, hardened=True)
<hdwallet.hdwallet.HDWallet object at 0x000001E8BFB98D60>
>>> isinstance(child_node, HDWallet)
True
```

Added return statement to `HDWallet.from_index` hardened key derivation.
Change return type to Optional to mirror the return type of called  method `HDWallet._derive_key_by_index`

Do let me know if the pull request is not formulated correctly.